### PR TITLE
refactor: add prompt_yes_no util

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ require('possession').setup {
     silent = false,
     load_silent = true,
     debug = false,
+    prompt_no_cr = false,
     commands = {
         save = 'PossessionSave',
         load = 'PossessionLoad',

--- a/doc/possession.txt
+++ b/doc/possession.txt
@@ -68,6 +68,13 @@ debug~
     `boolean`
     Show debug logs.
 
+prompt_no_cr~
+    `boolean`
+    When this option is set to true, yes/no prompts will use |getchar()| so
+    that there is no need to hit enter (`<CR>`) - just hit `y` or `n`. When
+    `prompt_no_cr = false`, `vim.ui.input` is used and you must hit enter to
+    confirm the answer.
+
 commands~
     `table | nil`
     If set to falsy value then no commands will be created.

--- a/lua/possession/config.lua
+++ b/lua/possession/config.lua
@@ -12,6 +12,7 @@ local function defaults()
         silent = false,
         load_silent = true,
         debug = false,
+        prompt_no_cr = false,
         commands = {
             save = 'PossessionSave',
             load = 'PossessionLoad',

--- a/lua/possession/session.lua
+++ b/lua/possession/session.lua
@@ -106,11 +106,11 @@ function M.save(name, opts)
         end
     end
 
+    -- ask for user configrmation if required
     if path:exists() and not opts.no_confirm then
-        local prompt = string.format('File "%s" exists, overwrite? [yN] ', short)
-        vim.ui.input({ prompt = prompt }, function(answer)
-            commit(vim.tbl_contains({ 'y', 'yes' }, answer and answer:lower()))
-        end)
+        if utils.prompt_yes_no(string.format('Overwrite session "%s"? y/n', name)) then
+          commit(true)
+        end
     else
         commit(true)
     end
@@ -198,11 +198,11 @@ function M.delete(name, opts)
         end
     end
 
+    -- ask for user configrmation if required
     if not opts.no_confirm then
-        local prompt = string.format('File "%s" exists, delete? [yN] ', short)
-        vim.ui.input({ prompt = prompt }, function(answer)
-            commit(vim.tbl_contains({ 'y', 'yes' }, answer and answer:lower()))
-        end)
+        if utils.prompt_yes_no(string.format('Delete session "%s"? y/n', name)) then
+          commit(true)
+        end
     else
         commit(true)
     end

--- a/lua/possession/session.lua
+++ b/lua/possession/session.lua
@@ -106,11 +106,9 @@ function M.save(name, opts)
         end
     end
 
-    -- ask for user configrmation if required
+    -- ask for user confirmation if required
     if path:exists() and not opts.no_confirm then
-        if utils.prompt_yes_no(string.format('Overwrite session "%s"? y/n', name)) then
-          commit(true)
-        end
+        utils.prompt_yes_no(string.format('Overwrite session "%s"?', name), commit)
     else
         commit(true)
     end
@@ -198,11 +196,9 @@ function M.delete(name, opts)
         end
     end
 
-    -- ask for user configrmation if required
+    -- ask for user confirmation if required
     if not opts.no_confirm then
-        if utils.prompt_yes_no(string.format('Delete session "%s"? y/n', name)) then
-          commit(true)
-        end
+        utils.prompt_yes_no(string.format('Delete session "%s"?', name), commit)
     else
         commit(true)
     end

--- a/lua/possession/utils.lua
+++ b/lua/possession/utils.lua
@@ -138,16 +138,20 @@ function M.clear_prompt()
 end
 
 -- Ask the user a y/n question
-function M.prompt_yes_no(prompt)
-    local is_confirmed = false
-    print(prompt)
-    local ans = vim.fn.nr2char(vim.fn.getchar())
-    if ans:match "^y" then
-        is_confirmed = true
+--@param callback function(boolean): receives true on "yes" and false on "no"
+function M.prompt_yes_no(prompt, callback)
+    prompt = string.format('%s [y/N] ', prompt)
+    if config.prompt_no_cr then -- use getchar so no <cr> is required
+        print(prompt)
+        local ans = vim.fn.nr2char(vim.fn.getchar())
+        local is_confirmed = ans:lower():match('^y')
+        M.clear_prompt()
+        callback(is_confirmed)
+    else -- use vim.ui.input
+        vim.ui.input({ prompt = prompt }, function(answer)
+            callback(vim.tbl_contains({ 'y', 'yes' }, answer and answer:lower()))
+        end)
     end
-    M.clear_prompt()
-    return is_confirmed
 end
-
 
 return M

--- a/lua/possession/utils.lua
+++ b/lua/possession/utils.lua
@@ -132,4 +132,22 @@ function M.is_type(types)
     end
 end
 
+-- Clear the prompt (whatever printed on the command line)
+function M.clear_prompt()
+    vim.api.nvim_command('normal! :')
+end
+
+-- Ask the user a y/n question
+function M.prompt_yes_no(prompt)
+    local is_confirmed = false
+    print(prompt)
+    local ans = vim.fn.nr2char(vim.fn.getchar())
+    if ans:match "^y" then
+        is_confirmed = true
+    end
+    M.clear_prompt()
+    return is_confirmed
+end
+
+
 return M


### PR DESCRIPTION
`vim.ui.input` is not suited for a y/n prompt since it required an enter after typing the answer.
however the main painpoint I had with it was how `vim.ui.input` is usually implemented via 3rd party plugins like `dressing.nvim`

[before](https://asciinema.org/a/sIZltA6T7n59nVdufe9Xnd2CM)
[after](https://asciinema.org/a/mdDx7ZgxFbLISuA9bsbdpe0CZ)