### PR TITLE
fix(close_windows): avoid errors when trying to close invalid windows

### DIFF
--- a/lua/possession/plugins/close_windows.lua
+++ b/lua/possession/plugins/close_windows.lua
@@ -37,7 +37,7 @@ function M.close_windows(opts)
     for _, win in ipairs(to_close) do
         -- Always close floating windows, others when not preserving layout
         if is_floating(win) or not preserve_layout(win) then
-            vim.api.nvim_win_close(win, false)
+            pcall(vim.api.nvim_win_close, win, false)
         else
             vim.api.nvim_win_set_buf(win, scratch())
         end


### PR DESCRIPTION
Possible fix for https://github.com/jedrzejboczar/possession.nvim/issues/20.