### PR TITLE
Trigger `SessionSavePre` autocmd before `mksession`

### DIFF
--- a/lua/possession/session.lua
+++ b/lua/possession/session.lua
@@ -70,6 +70,7 @@ function M.save(name, opts)
             return
         end
 
+        vim.api.nvim_exec_autocmds('User', { pattern = 'SessionSavePre' })
         vimscript = M.mksession()
     end
 


### PR DESCRIPTION
This is useful for other plugins that want to run something before the session gets saved. [Here's an example](https://github.com/romgrk/barbar.nvim/pull/347) of such a feature.