### PR TITLE
Add telescope.previewer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ require('possession').setup {
         delete_buffers = false,
     },
     telescope = {
-        show_previewer = true,
+        previewer = nil,   -- or false to disable previewer
         list = {
             default_action = 'load',
             mappings = {

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ require('possession').setup {
         delete_buffers = false,
     },
     telescope = {
+        show_previewer = true,
         list = {
             default_action = 'load',
             mappings = {

--- a/doc/possession.txt
+++ b/doc/possession.txt
@@ -264,9 +264,10 @@ telescope~
     `table`
     Configuration for builtin possession telescope pickers.
 
-telescope.show_previewer~
-    `boolean`
-    Show previewer for each session.
+telescope.previewer~
+    `string`
+    Show previewer for each session. By default is `nil`, which shows the
+    previewer. `false` disables previewer.
 
 telescope.list~
     `table`

--- a/doc/possession.txt
+++ b/doc/possession.txt
@@ -264,6 +264,10 @@ telescope~
     `table`
     Configuration for builtin possession telescope pickers.
 
+telescope.show_previewer~
+    `boolean`
+    Show previewer for each session.
+
 telescope.list~
     `table`
     List available sessions.

--- a/lua/possession/config.lua
+++ b/lua/possession/config.lua
@@ -64,7 +64,7 @@ local function defaults()
             delete_buffers = false,
         },
         telescope = {
-            show_previewer = true,
+            previewer = nil,
             list = {
                 default_action = 'load',
                 mappings = {

--- a/lua/possession/config.lua
+++ b/lua/possession/config.lua
@@ -64,6 +64,7 @@ local function defaults()
             delete_buffers = false,
         },
         telescope = {
+            show_previewer = true,
             list = {
                 default_action = 'load',
                 mappings = {

--- a/lua/possession/telescope.lua
+++ b/lua/possession/telescope.lua
@@ -94,7 +94,7 @@ function M.list(opts)
             prompt_title = 'Sessions',
             finder = get_finder(),
             sorter = conf.generic_sorter(opts),
-            previewer = config.telescope.show_previewer and session_previewer(opts) or false,
+            previewer = vim.F.if_nil(config.telescope.previewer, session_previewer(opts)),
             attach_mappings = function(prompt_buf, map)
                 local refresh = function()
                     local picker = action_state.get_current_picker(prompt_buf)

--- a/lua/possession/telescope.lua
+++ b/lua/possession/telescope.lua
@@ -94,7 +94,7 @@ function M.list(opts)
             prompt_title = 'Sessions',
             finder = get_finder(),
             sorter = conf.generic_sorter(opts),
-            previewer = session_previewer(opts),
+            previewer = config.telescope.show_previewer and session_previewer(opts) or false,
             attach_mappings = function(prompt_buf, map)
                 local refresh = function()
                     local picker = action_state.get_current_picker(prompt_buf)


### PR DESCRIPTION
Implements #42 with `true` as default. I think that this option should be `false` by default.