### PR TITLE
feat(plugins): neotest integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ require('possession').setup {
         tabby = true,
         dap = true,
         dapui = true,
+        neotest = true,
         delete_buffers = false,
     },
     telescope = {

--- a/doc/possession.txt
+++ b/doc/possession.txt
@@ -258,6 +258,10 @@ session.
 
 Closes and restores dapui view in a tab.
 
+                                                          *possession-neotest*
+
+Closes and restores the summary window.
+
                                                         *possession-telescope*
 
 telescope~

--- a/lua/possession/config.lua
+++ b/lua/possession/config.lua
@@ -61,6 +61,7 @@ local function defaults()
             tabby = true,
             dap = true,
             dapui = true,
+            neotest = true,
             delete_buffers = false,
         },
         telescope = {

--- a/lua/possession/plugins/init.lua
+++ b/lua/possession/plugins/init.lua
@@ -10,6 +10,7 @@ local plugins = {
     'neo_tree',
     'symbols_outline',
     'tabby',
+    'neotest',
     'dapui',
     'dap',
     'delete_buffers',

--- a/lua/possession/plugins/neotest.lua
+++ b/lua/possession/plugins/neotest.lua
@@ -1,0 +1,17 @@
+local plugins = require('possession.plugins')
+
+-- NOTE: similarly to dapui, neotest only supports up to a single summary open, so we can use the helper function
+return plugins.implement_file_tree_plugin_hooks('neotest', {
+    has_plugin = 'neotest',
+    buf_is_plugin = function(buf)
+        return vim.api.nvim_buf_get_option(buf, 'filetype') == 'neotest-summary'
+    end,
+    -- also similarly to dapui, it's necessary to call close(), because simply deleting the buffer causes an error
+    close_in_tab = function(_)
+        require('neotest').summary.close()
+        return true
+    end,
+    open_in_tab = function(_)
+        require('neotest').summary.open()
+    end,
+})


### PR DESCRIPTION
Hello!

This is just a simple integration with neotest. More specifically, it's summary. Currently, when the plugin tries to restore neotest's summary, an error is thrown. The integration fixes this issue, by using a workaround similar to dapui's: first calling `close()` and then calling `open()`. Neotest also provides others "views", such as the output panel, but I don't use them, so I can't say if they're causing trouble as of now, but I can take a look if you don't wanna merge an "incomplete" PR