### PR TITLE
feat(plugin): support fork of symbols-outline

### DIFF
--- a/lua/possession/plugins/symbols_outline.lua
+++ b/lua/possession/plugins/symbols_outline.lua
@@ -15,7 +15,14 @@ return plugins.implement_file_tree_plugin_hooks('symbols-outline', {
     has_plugin = 'symbols-outline',
     buf_is_plugin = buf_is_plugin,
     open_in_tab = function(tab)
-        vim.cmd('SymbolsOutlineOpen')
+        local _, has_outline = pcall(require, 'outline')
+
+        if has_outline then
+            vim.cmd('OutlineOpen')
+        else
+            vim.cmd('SymbolsOutlineOpen')
+        end
+
         -- Need to wait for some async stuff
         vim.wait(100, function()
             return find_tab_buf(tab) ~= nil


### PR DESCRIPTION
The symbols-outline.nvim plugin was archived, and there is a popular
fork that added some nice new features. The fork's filetype is still
"Outline", but the user commands have changed.

ref: https://github.com/hedyhli/outline.nvim
