### PR TITLE
Feature: last session filesystem time

### DIFF
--- a/lua/possession/commands.lua
+++ b/lua/possession/commands.lua
@@ -10,6 +10,8 @@ local display = utils.lazy_mod('possession.display')
 local paths = utils.lazy_mod('possession.paths')
 ---@module "possession.migrate"
 local migrate = utils.lazy_mod('possession.migrate')
+---@module "possession.query"
+local query = utils.lazy_mod('possession.query')
 
 local function complete_list(candidates, opts)
     opts = vim.tbl_extend('force', {
@@ -65,12 +67,14 @@ local function get_current()
 end
 
 local function get_last()
-    local path = session.last()
-    if not path then
+    local sessions = query.as_list()
+    query.sort_by(sessions, 'mtime', true)
+    local last_session = sessions and sessions[1]
+    if not last_session then
         utils.error('Cannot find last loaded session - specify session name as an argument')
         return nil
     end
-    return get_session_names()[path]
+    return last_session.name
 end
 
 local function name_or(name, getter)
@@ -96,6 +100,14 @@ function M.load(name)
     name = name_or(name, get_last)
     if name then
         session.load(name)
+        -- A session could be (auto) saved just before this one is
+        -- loaded, which means the previous session has the newer mtime
+        -- so :PossessionLoad will flip flop between the last two sessions.
+        -- This might be desireable, otherwise we can immediately save so
+        -- :PossessionLoad will only ever load a single session.
+        -- session.save(name, { no_confirm = true })
+        -- Ideally we don't write the exact same content again, we just
+        -- want something like `touch` to update the mtime.
     end
 end
 

--- a/lua/possession/commands.lua
+++ b/lua/possession/commands.lua
@@ -100,14 +100,6 @@ function M.load(name)
     name = name_or(name, get_last)
     if name then
         session.load(name)
-        -- A session could be (auto) saved just before this one is
-        -- loaded, which means the previous session has the newer mtime
-        -- so :PossessionLoad will flip flop between the last two sessions.
-        -- This might be desireable, otherwise we can immediately save so
-        -- :PossessionLoad will only ever load a single session.
-        -- session.save(name, { no_confirm = true })
-        -- Ideally we don't write the exact same content again, we just
-        -- want something like `touch` to update the mtime.
     end
 end
 

--- a/lua/possession/paths.lua
+++ b/lua/possession/paths.lua
@@ -12,11 +12,6 @@ function M.session(name)
     return Path:new(config.session_dir) / (utils.percent_encode(name) .. '.json')
 end
 
---- Get path to symlink that points to last session
-function M.last_session_link()
-    return Path:new(config.session_dir) / '__last__'
-end
-
 --- Get short session path for printing
 ---@param name string
 function M.session_short(name)

--- a/lua/possession/session.lua
+++ b/lua/possession/session.lua
@@ -160,7 +160,10 @@ end
 
 ---@return { name: string, variant: 'current'|'cwd'|'tmp' }?
 function M.autosave_info()
-    if state.session_name and utils.as_function(config.autosave.current)(state.session_name) then
+    if state.session_name then
+        if not utils.as_function(config.autosave.current)(state.session_name) then
+            return
+        end
         return { name = state.session_name, variant = 'current' }
     elseif utils.as_function(config.autosave.cwd)() then
         if autosave_skip() then
@@ -267,6 +270,11 @@ function M.load(name_or_data)
     config.hooks.after_load(session_data.name, user_data)
 
     utils.info('Loaded session "%s"', session_data.name)
+
+    -- update last session by updating modification time of session file (after any autosave)
+    if path then
+        utils.touch(path:absolute())
+    end
 end
 
 --- Close currently open session

--- a/lua/possession/utils.lua
+++ b/lua/possession/utils.lua
@@ -424,4 +424,12 @@ function M.percent_decode(str)
     end)
 end
 
+--- Update access and modification time of a file to the current time
+---@param path string
+function M.touch(path)
+    local sec, usec = vim.uv.gettimeofday()
+    local t = sec + usec / 1000000
+    vim.uv.fs_utime(path, t, t)
+end
+
 return M

--- a/plugin/possession.lua
+++ b/plugin/possession.lua
@@ -15,11 +15,12 @@ vim.api.nvim_create_autocmd('VimEnter', {
     callback = function()
         -- Be lazy when loading modules
         local config = require('possession.config')
-        local Path = require('plenary.path')
 
-        local symlink = Path:new(config.session_dir) / '__last__'
-        if symlink:exists() then
-            symlink:rm()
+        -- Delete old symlink that is not used anymore
+        -- TODO: remove when we explicitly drop support for nvim <0.10 which does not have vim.fs.joinpath
+        if vim.tbl_get(vim, 'fs', 'joinpath') then
+            local symlink = vim.fs.joinpath(config.session_dir, '__last__')
+            vim.fn.delete(symlink)
         end
 
         local utils = require('possession.utils')

--- a/plugin/possession.lua
+++ b/plugin/possession.lua
@@ -15,6 +15,13 @@ vim.api.nvim_create_autocmd('VimEnter', {
     callback = function()
         -- Be lazy when loading modules
         local config = require('possession.config')
+        local Path = require('plenary.path')
+
+        local symlink = Path:new(config.session_dir) / '__last__'
+        if symlink:exists() then
+            symlink:rm()
+        end
+
         local utils = require('possession.utils')
         if utils.as_function(config.autoload.cwd)() then
             local paths = require('possession.paths')


### PR DESCRIPTION
Here is an attempt at implementing the last session by using the filesystem last write time, instead of a symlink.

The symlink adds a bunch of complication about keeping it in sync, and I'm pretty syre there is a bug around deleting a session from telescope not removing the symlink. I'm also unsure how well supported these are on Windows.

The second commit in the PR serves to remove the symlink for exisiting users. We may wish to incorporate this, otherwise a symlink will persist unless the users manually remove it. I'm unsure how long this feature should remain, the alternative is to mark this as a possible breaking change and have the users clean up the symlink themselves. I'll leave this decision up to @jedrzejboczar as to how you want to manage this plugin.

There might very well be a much better way to implement this, but I found that the query module did most of what was needed already, so have just leveraged that. Please disregard any or all of this PR if there are better ways to achieve this feature. Treat this as a proof of concept.

Do note that when executing `:PossessionLoad` I get the following error, which might be an issue with my specific Neovim config, or it could be something I've done incorrectly in the PR.

<img width="1247" alt="Screen Shot 2024-06-11 at 21 33 47" src="https://github.com/jedrzejboczar/possession.nvim/assets/414204/c7322f9c-f5e6-4c2e-9ff3-59e8fbc8e3c5">

It's also worth noting the comment in `commands.lua` from line 98. Because autosave might be enabled, using mtime can trigger a flip flop effect if you run `:PossessionLoad` multiple times; it will toggle the last two sessions. We may or may not want this. The comment suggests ways to avoid this, but this toggling effect, or not, is open for discussion.