### PR TITLE
feat: prompt for name if none provided when saving.

### DIFF
--- a/doc/possession.txt
+++ b/doc/possession.txt
@@ -11,7 +11,8 @@ currently loaded session is used (unless noted otherwise).
 
 Save the current session information under `session_dir`. Use
 `:PossessionSave! [{name}]` to avoid asking for confirmation when overwriting
-existing session file.
+existing session file. If [{name}] is not provided and a session does not
+already exist, you will be prompted for a name. 
 
                                                              *:PossessionLoad*
 :PossessionLoad [{name}]~

--- a/lua/possession/commands.lua
+++ b/lua/possession/commands.lua
@@ -56,9 +56,11 @@ end
 M.complete_session = complete_list(get_session_names)
 
 local function get_current()
-    local name = session.get_session_name()
-    if not name then
-        utils.error('No session is currently open - specify session name as an argument')
+    return session.get_session_name()
+end
+local function prompt_for_name()
+    local name = vim.fn.input('Session name: ')
+    if not name or name == '' then
         return nil
     end
     return name
@@ -81,6 +83,7 @@ end
 ---@param no_confirm? boolean
 function M.save(name, no_confirm)
     name = name_or(name, get_current)
+    name = name_or(name, prompt_for_name)
     if name then
         session.save(name, { no_confirm = no_confirm })
     end

--- a/lua/possession/commands.lua
+++ b/lua/possession/commands.lua
@@ -56,7 +56,12 @@ end
 M.complete_session = complete_list(get_session_names)
 
 local function get_current()
-    return session.get_session_name()
+    local name = session.get_session_name()
+    if not name then
+        utils.error('No session is currently open - specify session name as an argument')
+        return nil
+    end
+    return name
 end
 
 local function get_last()
@@ -75,7 +80,7 @@ end
 ---@param name? string
 ---@param no_confirm? boolean
 function M.save(name, no_confirm)
-    name = name_or(name, get_current)
+    name = name_or(name, session.get_session_name)
     local save = function(session_name)
         session.save(session_name, { no_confirm = no_confirm })
     end

--- a/lua/possession/commands.lua
+++ b/lua/possession/commands.lua
@@ -58,13 +58,6 @@ M.complete_session = complete_list(get_session_names)
 local function get_current()
     return session.get_session_name()
 end
-local function prompt_for_name()
-    local name = vim.fn.input('Session name: ')
-    if not name or name == '' then
-        return nil
-    end
-    return name
-end
 
 local function get_last()
     local path = session.last()
@@ -83,9 +76,13 @@ end
 ---@param no_confirm? boolean
 function M.save(name, no_confirm)
     name = name_or(name, get_current)
-    name = name_or(name, prompt_for_name)
+    local save = function(session_name)
+        session.save(session_name, { no_confirm = no_confirm })
+    end
     if name then
-        session.save(name, { no_confirm = no_confirm })
+        save(name)
+    else
+        vim.ui.input({ prompt = 'Session name: ' }, save)
     end
 end
 

--- a/lua/possession/session.lua
+++ b/lua/possession/session.lua
@@ -107,6 +107,7 @@ function M.save(name, opts)
     local path = paths.session(name)
     local short = paths.session_short(name)
     local commit = function(ok)
+        utils.clear_prompt()
         if ok then
             vim.fn.mkdir(config.session_dir, 'p')
             path:write(vim.json.encode(session_data), 'w')
@@ -117,7 +118,7 @@ function M.save(name, opts)
 
             utils.info('Saved as "%s"', short)
         else
-            utils.info('Aborting')
+            utils.info('Aborting save')
         end
 
         if not opts.vimscript then
@@ -342,7 +343,7 @@ function M.delete(name, opts)
                 utils.info('Deleted "%s"', short)
             end
         else
-            utils.info('Aborting')
+            utils.info('Aborting delete')
         end
 
         if opts.callback then


### PR DESCRIPTION
I find that I'm often executing `:PossessionSave` on it's own and not specifying a session. If a session is not currently active, this does nothing (or perhaps gives a message, I don't remember the specifics).

This PR adjusts this behaviour so that if no session name is given it will
1. Save the current session if one exists (existing behaviour)
2. Prompt for a session name if no session exists (new behaviour)
If 2, then 3. Prompt to overwrite if config is set to prompt and session name exists (existing behaviour).

So this is just a small quality of life change. 

However, it might be that that Neo/vim conventions are such that you shouldn't be prompted, and that you specify the entire command (including session name) else error. I'm not familiar enough with Neo/vim conventions and idioms to answer this. I think this addition is helpful, but if this creates unexpected or unwanted Neo/vim behaviour that goes against the norms, then please reject the PR.

Small aside: it also fixes the issue where the prompt to overwrite is not cleared before outputting the save result message, resulting in both messages on a single line in the "status line" area.
<img width="443" alt="Screen Shot 2024-06-11 at 22 01 15" src="https://github.com/jedrzejboczar/possession.nvim/assets/414204/f0020365-da0c-41d4-9944-a92dba1fb197">

If this PR is not desired, it's a one line fix to keep the above, see `session.lua` line 110 of this PR for the fix.