### PR TITLE
feat: stop lsp clients plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ require('possession').setup {
         dapui = true,
         neotest = true,
         delete_buffers = false,
+        stop_lsp_clients = false,
     },
     telescope = {
         previewer = {

--- a/doc/possession.txt
+++ b/doc/possession.txt
@@ -307,6 +307,10 @@ Closes and restores dapui view in a tab.
 
 Closes and restores the summary window.
 
+                                                 *possession-stop-lsp-clients*
+
+Stops all attached language server protocol clients.
+
                                                         *possession-telescope*
 
 telescope~

--- a/lua/possession/config.lua
+++ b/lua/possession/config.lua
@@ -69,6 +69,7 @@ local function defaults()
             dapui = true,
             neotest = true,
             delete_buffers = false,
+            stop_lsp_clients = false,
         },
         telescope = {
             previewer = {

--- a/lua/possession/plugins/init.lua
+++ b/lua/possession/plugins/init.lua
@@ -15,6 +15,7 @@ local plugins = {
     'dapui',
     'dap',
     'delete_buffers',
+    'stop_lsp_clients',
 }
 
 local function req(plugin)

--- a/lua/possession/plugins/stop_lsp_clients.lua
+++ b/lua/possession/plugins/stop_lsp_clients.lua
@@ -1,0 +1,10 @@
+local M = {}
+
+local utils = require('possession.utils')
+
+function M.before_load(_, _, plugin_data)
+    utils.stop_lsp_clients()
+    return plugin_data
+end
+
+return M

--- a/lua/possession/session.lua
+++ b/lua/possession/session.lua
@@ -291,6 +291,7 @@ function M.close(force)
     end
 
     utils.delete_all_buffers(force)
+    utils.stop_lsp_clients()
     state.session_name = nil
 end
 

--- a/lua/possession/utils.lua
+++ b/lua/possession/utils.lua
@@ -214,12 +214,15 @@ local function lsp_get_clients(filter)
     end
 end
 
+--- Stops all attached LSP clients
+function M.stop_lsp_clients()
+    vim.lsp.stop_client(lsp_get_clients())
+end
+
 --- Delete all open buffers, avoiding potential errors
 ---@param force? boolean delete buffers with unsaved changes
 function M.delete_all_buffers(force)
     -- Deleting the current buffer before deleting other buffers will cause autocmd "BufEnter" to be triggered.
-    -- Lspconfig will use the invalid buffer handler in vim.schedule.
-    -- So make sure the current buffer is the last loaded one to delete.
     local current_buffer = vim.api.nvim_get_current_buf()
     for _, buffer in ipairs(vim.api.nvim_list_bufs()) do
         if vim.api.nvim_buf_is_valid(buffer) and current_buffer ~= buffer then
@@ -227,7 +230,6 @@ function M.delete_all_buffers(force)
         end
     end
     vim.api.nvim_buf_delete(current_buffer, { force = force })
-    vim.lsp.stop_client(lsp_get_clients())
 end
 
 ---@param mod string


### PR DESCRIPTION
This PR extracts the stopping of the LSP clients from the `delete_buffers` plugin to a separate plugin.

It does introduce possible breaking changes. If a user has `delete_buffers` set to `true`, then the LSPs will no longer be stopped since the plugin config defaults to `false` (which is the same default as `delete_buffers`). 

If we change the LSP default config to `true`, then it breaks behaviour for those users with `delete_buffers` set to `false`. So there is no win.

We could implement a possible config patch if this is desirable. Given the default Neovim behaviour is to do nothing with attached LSPs when you normally delete buffers, I think the default of `false` is sufficient, and there is no need for a config patch. But the final decision is with you on how to proceed.

Closes #66 