### PR TITLE
feat: call telescope without load_extension

### DIFF
--- a/lua/telescope/_extensions/possession.lua
+++ b/lua/telescope/_extensions/possession.lua
@@ -4,5 +4,6 @@ local pickers = require('possession.telescope')
 return telescope.register_extension {
     exports = {
         list = pickers.list,
+        possession = pickers.list,
     },
 }


### PR DESCRIPTION
With this patch, you can call `:Telescope possession` when you have not called `telescope.load_extension()` before.

See https://github.com/nvim-telescope/telescope.nvim/pull/2655

NOTE: You still need to call `load_extension()` for calling `telescope.extensions.possession.list()` / `.possession()`.