### PR TITLE
feat: add `live_grep` and `find_files` keymap in possession Telescope…

### DIFF
--- a/lua/possession/config.lua
+++ b/lua/possession/config.lua
@@ -89,6 +89,8 @@ local function defaults()
                     load = { n = '<c-v>', i = '<c-v>' },
                     delete = { n = '<c-t>', i = '<c-t>' },
                     rename = { n = '<c-r>', i = '<c-r>' },
+                    grep = { n = 'c-g', i = '<c-g>' },
+                    find = { n = '<c-f>', i = '<c-f>' },
                 },
             },
         },

--- a/lua/possession/telescope.lua
+++ b/lua/possession/telescope.lua
@@ -61,6 +61,14 @@ local session_actions = {
             end
         end)
     end,
+    grep = function(prompt_buf, entry, refresh)
+        actions.close(prompt_buf)
+        require('telescope.builtin').live_grep({ cwd = entry.value.cwd, prompt_title = ('Live Grep (%s)'):format(entry.value.name) })
+    end,
+    find = function(prompt_buf, entry, refresh)
+        actions.close(prompt_buf)
+        require('telescope.builtin').find_files({ cwd = entry.value.cwd, prompt_title = ('Find files (%s)'):format(entry.value.name) })
+    end,
 }
 
 ---@class possession.TelescopeListOpts


### PR DESCRIPTION
`live_grep` and `find_files` are Telescope builtin picker. It's very useful to grep and find files in session/projects while working on some other project without loading the session.