### PR TITLE
feat: add `live_grep` and `find_files` keymapping to telescope picker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ require('possession').setup {
                 load = { n = '<c-v>', i = '<c-v>' },
                 delete = { n = '<c-t>', i = '<c-t>' },
                 rename = { n = '<c-r>', i = '<c-r>' },
+                grep   = { n = '<c-g>', i = '<c-g>' },
+                find   = { n = '<c-f>', i = '<c-f>' },
             },
         },
     },

--- a/lua/possession/config.lua
+++ b/lua/possession/config.lua
@@ -89,6 +89,8 @@ local function defaults()
                     load = { n = '<c-v>', i = '<c-v>' },
                     delete = { n = '<c-t>', i = '<c-t>' },
                     rename = { n = '<c-r>', i = '<c-r>' },
+                    grep   = { n = '<c-g>', i = '<c-g>' },
+                    find   = { n = '<c-f>', i = '<c-f>' },
                 },
             },
         },

--- a/lua/possession/telescope.lua
+++ b/lua/possession/telescope.lua
@@ -63,17 +63,17 @@ local session_actions = {
     end,
     grep = function(prompt_buf, entry, refresh)
         actions.close(prompt_buf)
-        require('telescope.builtin').live_grep({
+        require('telescope.builtin').live_grep {
             cwd = entry.value.cwd,
             prompt_title = ('Live Grep (%s)'):format(entry.value.name),
-        })
+        }
     end,
     find = function(prompt_buf, entry, refresh)
         actions.close(prompt_buf)
-        require('telescope.builtin').find_files({
+        require('telescope.builtin').find_files {
             cwd = entry.value.cwd,
             prompt_title = ('Find Files (%s)'):format(entry.value.name),
-        })
+        }
     end,
 }
 

--- a/lua/possession/telescope.lua
+++ b/lua/possession/telescope.lua
@@ -61,6 +61,20 @@ local session_actions = {
             end
         end)
     end,
+    grep = function(prompt_buf, entry, refresh)
+        actions.close(prompt_buf)
+        require('telescope.builtin').live_grep({
+            cwd = entry.value.cwd,
+            prompt_title = ('Live Grep (%s)'):format(entry.value.name),
+        })
+    end,
+    find = function(prompt_buf, entry, refresh)
+        actions.close(prompt_buf)
+        require('telescope.builtin').find_files({
+            cwd = entry.value.cwd,
+            prompt_title = ('Find Files (%s)'):format(entry.value.name),
+        })
+    end,
 }
 
 ---@class possession.TelescopeListOpts


### PR DESCRIPTION
This is very useful addition to the Possession Telescope picker. One can `live_grep` and `find_file` on session directory without loading the session.

Note: This are Telescope builtin pickers. No additional dependency needed.