### PR TITLE
feat(plugins): kulala integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ require('possession').setup {
         dap = true,
         dapui = true,
         neotest = true,
+        kulala = true,
         delete_buffers = false,
         stop_lsp_clients = false,
     },

--- a/doc/possession.txt
+++ b/doc/possession.txt
@@ -307,6 +307,10 @@ Closes and restores dapui view in a tab.
 
 Closes and restores the summary window.
 
+                                                          *possession-kulala*
+
+Closes the UI
+
                                                  *possession-stop-lsp-clients*
 
 Stops all attached language server protocol clients.

--- a/lua/possession/config.lua
+++ b/lua/possession/config.lua
@@ -68,6 +68,7 @@ local function defaults()
             dap = true,
             dapui = true,
             neotest = true,
+            kulala = true,
             delete_buffers = false,
             stop_lsp_clients = false,
         },

--- a/lua/possession/plugins/init.lua
+++ b/lua/possession/plugins/init.lua
@@ -12,6 +12,7 @@ local plugins = {
     'outline',
     'tabby',
     'neotest',
+    'kulala',
     'dapui',
     'dap',
     'delete_buffers',
@@ -141,7 +142,7 @@ end
 
 ---@class possession.FileTreePluginOpts
 ---@field buf_is_plugin fun(buf: integer): boolean check if given buffer belongs to the plugin, e.g. by filetype
----@field open_in_tab fun(tab: integer) open the plugin in tab (tab is the current tab when this function is called)
+---@field open_in_tab? fun(tab: integer) open the plugin in tab (tab is the current tab when this function is called)
 ---@field close_in_tab? fun(tab: integer): boolean if not provided then deletes all plugin buffers
 ---@field has_plugin? string|fun(): boolean if it is a string will try to require lua module, if nil then assume true
 
@@ -187,7 +188,9 @@ function M.implement_file_tree_plugin_hooks(name, opts)
 
     local open_in_tab_nums = function(tab_nums)
         local tabs = utils.tab_nums_to_ids(tab_nums)
-        utils.for_each_tab(tabs, opts.open_in_tab)
+        if opts.open_in_tab then
+            utils.for_each_tab(tabs, opts.open_in_tab)
+        end
     end
 
     local has_plugin = function()

--- a/lua/possession/plugins/kulala.lua
+++ b/lua/possession/plugins/kulala.lua
@@ -1,0 +1,7 @@
+local plugins = require('possession.plugins')
+
+return plugins.implement_file_tree_plugin_hooks('kulala', {
+    buf_is_plugin = function(buf)
+        return vim.api.nvim_buf_get_name(buf) == 'kulala://ui'
+    end,
+})


### PR DESCRIPTION
Hello!

This is a pretty simple integration that adds support to [kulala](https://github.com/mistweaverco/kulala.nvim), an HTTP client in neovim.

Basically, kulala creates a window that's useless on session restore, so all the integration does is get rid of that.